### PR TITLE
Remove bizaare string escape and decode

### DIFF
--- a/static/js/main.js
+++ b/static/js/main.js
@@ -66,8 +66,7 @@ exports.handleClientMessage_CUSTOM = (hookName, context) => {
 
   // an author has sent this client a chat message update, we need to show it in the dom
   if (action === 'recieveChatMessage') {
-    authorName = decodeURI(escape(context.payload.authorName));
-    if (authorName === 'null') {
+    if (authorName == null) {
       authorName = 'Anonymous'; // If the users username isn't set then display a smiley face
     }
     $(`#authorChatMessage-${authorClass}`).remove();


### PR DESCRIPTION
I am scratching my head trying to figure out how the bizarre `decodeURI(escape(authorName))` code came to be. It causes "URIError: URI malformed" errors when `authorName` contains a character with code point 0xff or greater, so I'm removing it.