### PR TITLE
docs: use a human-readable README title

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 ![Publish Status](https://github.com/ether/ep_real_time_chat/workflows/Node.js%20Package/badge.svg) [![Backend Tests Status](https://github.com/ether/ep_real_time_chat/actions/workflows/test-and-release.yml/badge.svg)](https://github.com/ether/ep_real_time_chat/actions/workflows/test-and-release.yml)
 
-# ep_real_time_chat
+# Real-Time Chat Preview for Etherpad
 Etherpad plugin to send real time chat updates
 
 ## Configuring


### PR DESCRIPTION
Replace the placeholder `ep_real_time_chat` heading in README.md with "Real-Time Chat Preview for Etherpad" so browsers of the plugin list on GitHub / npm can see what the plugin does at a glance.